### PR TITLE
Add districtCode to USIGNormalizadorAddress and bugfixes

### DIFF
--- a/USIGNormalizador/USIGNormalizador.swift
+++ b/USIGNormalizador/USIGNormalizador.swift
@@ -67,7 +67,8 @@ public class USIGNormalizador {
                     type: (item["tipo"] as! String).trimmingCharacters(in: .whitespacesAndNewlines),
                     corner: item["nombre_calle_cruce"] as? String,
                     latitude: latitude,
-                    longitude: longitude
+                    longitude: longitude,
+                    districtCode: item["cod_partido"] as? String
                 )
                 
                 result.append(address)
@@ -103,7 +104,8 @@ public class USIGNormalizador {
                 type: type.trimmingCharacters(in: .whitespacesAndNewlines),
                 corner: (json?["nombre_calle_cruce"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
                 latitude: latitude,
-                longitude: longitude
+                longitude: longitude,
+                districtCode: json?["cod_partido"] as? String
             )
             
             completion(result, nil)

--- a/USIGNormalizador/USIGNormalizadorAPI.swift
+++ b/USIGNormalizador/USIGNormalizadorAPI.swift
@@ -36,7 +36,12 @@ extension USIGNormalizadorAPI: TargetType {
     public var parameters: [String: Any]? {
         switch self {
         case .normalizar(let direccion, let excluyendo, let geocodificar, let max):
-            return ["direccion": direccion, "geocodificar": geocodificar, "maxOptions": max, "exclude": excluyendo ?? ""]
+            return [
+					"direccion": direccion,
+					"geocodificar": geocodificar ? "true" : "false",
+					"maxOptions": max,
+					"exclude": excluyendo ?? ""
+				]
         case .normalizarCoordenadas(let latitud, let longitud):
             return ["lat": latitud, "lng": longitud]
         }

--- a/USIGNormalizador/USIGNormalizadorAddress.swift
+++ b/USIGNormalizador/USIGNormalizadorAddress.swift
@@ -16,6 +16,7 @@ public struct USIGNormalizadorAddress {
     public let corner: String?
     public let latitude: Double?
     public let longitude: Double?
+    public let districtCode: String?
 }
 
 extension USIGNormalizadorAddress: Equatable {

--- a/USIGNormalizador/USIGNormalizadorController.swift
+++ b/USIGNormalizador/USIGNormalizadorController.swift
@@ -227,10 +227,8 @@ public class USIGNormalizadorController: UIViewController {
 
         for item in addresses {
             let coordinates = item["coordenadas"] as? [String: Any]
-            let latitudeString = coordinates?["y"] as? String
-            let longitudeString = coordinates?["x"] as? String
-            let latitude = latitudeString != nil ? Double(latitudeString!) : nil
-            let longitude = longitudeString != nil ? Double(longitudeString!) : nil
+            let latitude = parseCoordinate( fromCoodinatesDict: coordinates, coordinateKey: "y" )
+            let longitude = parseCoordinate( fromCoodinatesDict: coordinates, coordinateKey: "x" )
             
             let address = USIGNormalizadorAddress(
                 address: (item["direccion"] as! String).trimmingCharacters(in: whitespace).uppercased(),
@@ -278,6 +276,16 @@ public class USIGNormalizadorController: UIViewController {
         else {
             reloadTable()
         }
+    }
+
+    private func parseCoordinate( fromCoodinatesDict coordinatesDict: [ String: Any ]?, coordinateKey: String ) -> Double? {
+        guard let coordinatesDict = coordinatesDict else { return nil }
+
+        if let coordinateString = coordinatesDict [ coordinateKey ] as? String {
+            return Double( coordinateString )
+        }
+
+        return coordinatesDict [ coordinateKey ] as? Double
     }
 
     private func handleError(_ error: Swift.Error) {

--- a/USIGNormalizador/USIGNormalizadorController.swift
+++ b/USIGNormalizador/USIGNormalizadorController.swift
@@ -237,7 +237,8 @@ public class USIGNormalizadorController: UIViewController {
                 type: (item["tipo"] as! String).trimmingCharacters(in: whitespace),
                 corner: item["nombre_calle_cruce"] as? String,
                 latitude: latitude,
-                longitude: longitude
+                longitude: longitude,
+                districtCode: item["cod_partido"] as? String
             )
 
             self.results.append(address)


### PR DESCRIPTION
- Add district code to USIGNormalizadorAddress.
- Fix not sending the 'geocodificar' parameter correctly when searching addresses.
- Fix AMBA coordinates as Doubles issue.
